### PR TITLE
feat : 이슈 목록, 이슈 상세내용을 가져오는 api 함수와 상태 구현 #3

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,1 +1,13 @@
-export {};
+import axios from 'axios';
+import GITHUB_BASE_URL from '../constants/base-url';
+
+const AxiosFetch = axios.create({
+  baseURL: GITHUB_BASE_URL,
+  headers: {
+    Authorization: `Bearer ${process.env.REACT_APP_GITHUB_API_KEY}`,
+    'Content-Type': 'application/json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  },
+});
+
+export default AxiosFetch;

--- a/src/api/get-issues.ts
+++ b/src/api/get-issues.ts
@@ -1,0 +1,21 @@
+import AxiosFetch from './api';
+
+export const getIssueList = async (org: string, repo: string, page: number) => {
+  try {
+    const { data } = await AxiosFetch.get(
+      `/repos/${org}/${repo}/issues?state=open&sort=comments&page=${page}`,
+    );
+    return data;
+  } catch (error) {
+    return error;
+  }
+};
+
+export const getDetailIssue = async (org: string, repo: string, issueNumber: number) => {
+  try {
+    const { data } = await AxiosFetch.get(`repos/${org}/${repo}/issues/${issueNumber}`);
+    return data;
+  } catch (error) {
+    return error;
+  }
+};

--- a/src/constants/base-url.ts
+++ b/src/constants/base-url.ts
@@ -1,0 +1,3 @@
+const GITHUB_BASE_URL = 'https://api.github.com';
+
+export default GITHUB_BASE_URL;

--- a/src/hooks/useDetailIssue.ts
+++ b/src/hooks/useDetailIssue.ts
@@ -1,0 +1,76 @@
+// TODO
+// 1. 상태 가져오기
+// 2. 리듀서 함수 구현
+// 3. 액션 타입 설정하기
+
+import { useEffect, useReducer } from 'react';
+import { DetailIssueItem } from '../types/issues';
+import { getDetailIssue } from '../api/get-issues';
+import axios from 'axios';
+
+interface DetailIssueState {
+  detailIssue: DetailIssueItem | Record<string, never>;
+  isLoading: boolean;
+  error: string | Error;
+}
+
+const ACTION_TYPE = {
+  SUCCESS: 'SUCCESS',
+  LOADING: 'LOADING',
+  ERROR: 'ERROR',
+} as const;
+
+interface Action {
+  type: (typeof ACTION_TYPE)[keyof typeof ACTION_TYPE];
+  payload?: {
+    detailIssue?: DetailIssueItem;
+    error?: string | Error;
+  };
+}
+
+const detailIssueReducer = (state: DetailIssueState, action: Action): DetailIssueState => {
+  switch (action.type) {
+    case ACTION_TYPE.SUCCESS:
+      return {
+        ...state,
+        isLoading: false,
+        detailIssue: action.payload?.detailIssue as DetailIssueItem,
+      };
+    case ACTION_TYPE.LOADING:
+      return { ...state, isLoading: true };
+    case ACTION_TYPE.ERROR: {
+      return { ...state, error: action.payload?.error as string | Error };
+    }
+  }
+};
+
+const useDetailIssue = (org: string, repo: string, issueNumber: number) => {
+  const [state, dispatch] = useReducer(detailIssueReducer, {
+    detailIssue: {},
+    isLoading: false,
+    error: '',
+  });
+
+  useEffect(() => {
+    const getIssue = async () => {
+      dispatch({ type: ACTION_TYPE.LOADING });
+      try {
+        const detailIssue = await getDetailIssue(org, repo, issueNumber);
+        dispatch({
+          type: ACTION_TYPE.SUCCESS,
+          payload: { detailIssue: detailIssue as DetailIssueItem },
+        });
+      } catch (error) {
+        if (axios.isAxiosError(error) || error instanceof Error) {
+          dispatch({ type: ACTION_TYPE.ERROR, payload: { error: error } });
+        }
+      }
+    };
+
+    getIssue();
+  }, [issueNumber]);
+
+  return { ...state };
+};
+
+export default useDetailIssue;

--- a/src/hooks/useIssues.ts
+++ b/src/hooks/useIssues.ts
@@ -1,0 +1,83 @@
+import { useCallback, useEffect, useReducer } from 'react';
+import { IssueListItem } from '../types/issues';
+import axios from 'axios';
+import { getIssueList } from '../api/get-issues';
+
+interface IssueState {
+  issues: IssueListItem[] | [];
+  isLoading: boolean;
+  error: string | Error;
+  currentPage: number;
+}
+
+const ACTION_TYPE = {
+  SUCCESS: 'SUCCESS',
+  LOADING: 'LOADING',
+  ERROR: 'ERROR',
+  NEXT: 'NEXT',
+} as const;
+
+interface Action {
+  type: (typeof ACTION_TYPE)[keyof typeof ACTION_TYPE];
+  payload?: {
+    issues?: IssueListItem[];
+    error?: string | Error;
+  };
+}
+
+const IssueListReducer = (state: IssueState, action: Action): IssueState => {
+  switch (action.type) {
+    case ACTION_TYPE.SUCCESS:
+      return {
+        ...state,
+        isLoading: false,
+        issues: [...state.issues, ...(action.payload?.issues || [])],
+      };
+    case ACTION_TYPE.LOADING:
+      return { ...state, isLoading: true };
+    case ACTION_TYPE.ERROR:
+      return { ...state, error: action.payload?.error || '' };
+    case ACTION_TYPE.NEXT:
+      return { ...state, currentPage: state.currentPage + 1 };
+    default:
+      return { ...state };
+  }
+};
+
+const useIssues = (org: string, repo: string) => {
+  const [state, dispatch] = useReducer(IssueListReducer, {
+    issues: [],
+    currentPage: 1,
+    isLoading: false,
+    error: '',
+  });
+
+  const setNextPage = useCallback(() => {
+    dispatch({ type: ACTION_TYPE.NEXT });
+  }, [dispatch]);
+
+  useEffect(() => {
+    dispatch({ type: ACTION_TYPE.LOADING });
+    const getIssues = async () => {
+      try {
+        const issueList = await getIssueList(org, repo, state.currentPage);
+        dispatch({
+          type: ACTION_TYPE.SUCCESS,
+          payload: { issues: issueList as IssueListItem[] },
+        });
+      } catch (error) {
+        if (axios.isAxiosError(error) || error instanceof Error) {
+          dispatch({ type: ACTION_TYPE.ERROR, payload: { error: error } });
+        }
+      }
+    };
+    getIssues();
+  }, [state.currentPage]);
+
+  return {
+    ...state,
+    setNextPage,
+  };
+};
+
+export default useIssues;

--- a/src/types/issues.ts
+++ b/src/types/issues.ts
@@ -1,0 +1,14 @@
+export interface IssueListItem {
+  number: number;
+  title: string;
+  user: {
+    login: string;
+    avatar_url: string;
+  };
+  comments: number;
+  created_at: string;
+}
+
+export interface DetailIssueItem extends IssueListItem {
+  body: string;
+}


### PR DESCRIPTION
## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

-->
- 이슈 목록과 이슈 상세 내용을 가져오는 api함수를 구현했습니다.
- `useReducer` 훅을 사용해서 목록, 상세내용의 상태를 관리합니다.

## 💫 설명

<!--

- 현재 Pr 설명

-->
- useIssues
  - `organization`, `repository` 이름을 인자로 넘겨서 사용할 수 있습니다.
  - issues : 이슈 목록
  - isLoading : 이슈 목록을 가져올 때 까지 로딩처리 가능
  - error : error가 있는 경우에 에러 메세지
  - setNextPage : 무한 스크롤을 구현할 때 `callback` 함수를 넘겨줘야 하는데 이 함수를 넘겨주면 교차영역에 진입했을 경우 호출 되어서 다음 페이지의 데이터를 가져올 수 있습니다.
```ts
const {issues, isLoading, error, setNextPage}= useIssues('facebook', 'react')
```

- useDetailIssue
  - `organization`, `repository`, `issueNumber` 이름을 인자로 넘겨서 사용할 수 있습니다.
  -  detailIssue : 이슈 상세내용 데이터(객체), 객체 내부에 body 프로퍼티가 있고 마크다운 라이브러리 쓰실 때 사용하시면 됩니다.
  - isLoading : 이슈 상세내용을 가져올 때 까지 로딩처리 가능
  - error : error가 있는 경우에 에러 메세지
```ts
const {detailIssue, isLoading, error}= useDetailIssue('facebook', 'react', 13991)
```

- 이슈 목록, 이슈 상세 내용 타입 설정
> api 호출을 통해서, 얻는 데이터에 스킴이 너무 많아서 사용하는 데이터 스킴만 쓸 수 있도록 타입을 설정했습니다
```ts
export interface IssueListItem {
  number: number;
  title: string;
  user: {
    login: string;
    avatar_url: string;
  };
  comments: number;
  created_at: string;
}

export interface DetailIssueItem extends IssueListItem {
  body: string;
}
```
## 📷 스크린샷 (Optional)
- 사용하는 데이터 스킴만 쓸 수 있도록 타입 설정
<img width="559" alt="Screenshot 2023-08-31 at 21 05 41" src="https://github.com/wanted-internship-12-9/pre-onboarding-12th-2-9/assets/68489467/b9701fa3-ec42-4a91-9b2c-0f85c637b1a0">

<img width="561" alt="Screenshot 2023-08-31 at 21 05 49" src="https://github.com/wanted-internship-12-9/pre-onboarding-12th-2-9/assets/68489467/5ee5ed33-56ec-4e12-8151-2ffedc7ff431">

